### PR TITLE
Resolves #20 - json requests

### DIFF
--- a/resource/encoding.go
+++ b/resource/encoding.go
@@ -16,6 +16,9 @@ var JSONEncoding Encoding = jsonEncoding{}
 type jsonEncoding struct{}
 
 func (jsonEncoding) Decode(r *http.Request, entity interface{}) error {
+	if r.Header.Get("Content-Type") != "application/json" {
+		return errBadRequest
+	}
 	buf, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		return err

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -94,6 +94,7 @@ func runRequest(s *server.Server, method, path, body string) {
 		bodyReader = strings.NewReader(body)
 	}
 	r := httptest.NewRequest(method, path, bodyReader)
+	r.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	s.ServeHTTP(w, r)
 	fmt.Print(w.Code)


### PR DESCRIPTION
Assert that requests to JSON endpoints have a MIME type of
`application/json`. This requires updating a server-level test.